### PR TITLE
Add theme accent sync feature with room selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ manage your devices.
 - **Scenes**: Easily switch between your predefined scenes for each room
 - **Device icons**: Maps your Philips Hue icons to the closest equivalent from
   Material Symbols
+- **Theme accent sync**: Automatically syncs your lights to the current DMS
+  accent colour whenever the theme changes, light/dark mode toggles, or
+  Matugen generates new colours from your wallpaper. You can select which
+  rooms to sync, or leave it empty to sync all rooms.
 
 ## Installation
 
@@ -71,7 +75,16 @@ also stored in `~/.config/DankMaterialShell/plugin_settings.json`:
     "openHuePath": "openhue",
     "jqPath": "jq",
     "enabled": true,
-    "useDeviceIcons": true
+    "useDeviceIcons": true,
+    "autoSyncAccent": false
   }
 }
 ```
+
+### Theme Sync
+
+| Setting | Description |
+|---------|-------------|
+| **Auto-Sync Accent Colour** | When enabled, your colour-capable lights automatically update to match the DMS accent colour on theme changes |
+| **Sync Rooms** | Choose specific rooms to sync (empty selection = all rooms) |
+| **Sync Now** | Manually apply the current accent colour to your lights |

--- a/src/HueSettings.qml
+++ b/src/HueSettings.qml
@@ -5,6 +5,7 @@ import qs.Modules.Plugins
 import qs.Widgets
 
 PluginSettings {
+    id: root
     pluginId: "hueManager"
 
     // Cache the room list so the Repeater only rebuilds when rooms actually change
@@ -133,21 +134,23 @@ PluginSettings {
             }
 
             Repeater {
-                model: roomList
+                model: root.roomList
 
                 delegate: Row {
+                    id: roomDelegate
+                    required property var modelData
+
                     spacing: Theme.spacingS
                     anchors.left: parent.left
 
-CheckBox {
+                    CheckBox {
                         id: roomCheck
-                        checked: HueService._syncRoomIds.has(modelData.entityId)
-                        onCheckedChanged: {
-                            const sel = HueService._syncRoomIds;
+                        Component.onCompleted: checked = HueService._syncRoomIds.has(roomDelegate.modelData.entityId)
+                        onClicked: {
                             if (checked) {
-                                sel.add(modelData.entityId);
+                                HueService._syncRoomIds.add(roomDelegate.modelData.entityId);
                             } else {
-                                sel.delete(modelData.entityId);
+                                HueService._syncRoomIds.delete(roomDelegate.modelData.entityId);
                             }
                             HueService.saveSyncRoomIds();
                         }
@@ -155,7 +158,7 @@ CheckBox {
 
                     StyledText {
                         anchors.verticalCenter: parent.verticalCenter
-                        text: modelData.name
+                        text: roomDelegate.modelData.name
                         font.pixelSize: Theme.fontSizeSmall
                         color: Theme.surfaceText
                     }
@@ -188,7 +191,7 @@ CheckBox {
                         id: accentPreview
                         width: 32
                         height: 32
-                        radius: Theme.cornerRadiusSmall
+                        radius: Theme.cornerRadius
                         color: Theme.currentThemeData?.primary ?? "#42a5f5"
                         border.width: 1
                         border.color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.2)

--- a/src/HueSettings.qml
+++ b/src/HueSettings.qml
@@ -7,6 +7,9 @@ import qs.Widgets
 PluginSettings {
     pluginId: "hueManager"
 
+    // Cache the room list so the Repeater only rebuilds when rooms actually change
+    property var roomList: Array.from(HueService.rooms.values())
+
     StyledText {
         width: parent.width
         text: "Hue Manager Settings"
@@ -130,7 +133,7 @@ PluginSettings {
             }
 
             Repeater {
-                model: Array.from(HueService.rooms.values())
+                model: roomList
 
                 delegate: Row {
                     spacing: Theme.spacingS
@@ -147,8 +150,20 @@ PluginSettings {
                             if (checked) {
                                 sel.add(modelData.entityId);
                             } else {
-                                sel.delete(modelData.entityId);
+                                // When unchecking from "all rooms" state (empty set),
+                                // populate the set with all rooms except this one
+                                if (sel.size === 0) {
+                                    const allRooms = HueService.rooms.values();
+                                    for (const room of allRooms) {
+                                        if (room.entityId !== modelData.entityId) {
+                                            sel.add(room.entityId);
+                                        }
+                                    }
+                                } else {
+                                    sel.delete(modelData.entityId);
+                                }
                             }
+                            HueService.saveSyncRoomIds();
                         }
                     }
 

--- a/src/HueSettings.qml
+++ b/src/HueSettings.qml
@@ -126,7 +126,7 @@ PluginSettings {
 
             StyledText {
                 width: parent.width
-                text: "Choose which rooms to sync. Empty selection = all rooms."
+                text: "Choose which rooms to sync. All rooms are selected by default."
                 font.pixelSize: Theme.fontSizeSmall - 1
                 color: Theme.surfaceVariantText
                 wrapMode: Text.WordWrap
@@ -139,29 +139,15 @@ PluginSettings {
                     spacing: Theme.spacingS
                     anchors.left: parent.left
 
-                    CheckBox {
+CheckBox {
                         id: roomCheck
-                        checked: {
-                            const sel = HueService._syncRoomIds;
-                            return sel.size === 0 || sel.has(modelData.entityId);
-                        }
+                        checked: HueService._syncRoomIds.has(modelData.entityId)
                         onCheckedChanged: {
                             const sel = HueService._syncRoomIds;
                             if (checked) {
                                 sel.add(modelData.entityId);
                             } else {
-                                // When unchecking from "all rooms" state (empty set),
-                                // populate the set with all rooms except this one
-                                if (sel.size === 0) {
-                                    const allRooms = HueService.rooms.values();
-                                    for (const room of allRooms) {
-                                        if (room.entityId !== modelData.entityId) {
-                                            sel.add(room.entityId);
-                                        }
-                                    }
-                                } else {
-                                    sel.delete(modelData.entityId);
-                                }
+                                sel.delete(modelData.entityId);
                             }
                             HueService.saveSyncRoomIds();
                         }

--- a/src/HueSettings.qml
+++ b/src/HueSettings.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import qs.Common
 import qs.Modules.Plugins
 import qs.Widgets
@@ -55,6 +56,186 @@ PluginSettings {
                 label: "Use Device Icons"
                 description: "Use specific icons for different types of Hue devices."
                 defaultValue: HueService.defaults.useDeviceIcons
+            }
+        }
+    }
+
+    StyledRect {
+        width: parent.width
+        height: 1
+        color: Theme.outline
+        opacity: 0.3
+    }
+
+    StyledText {
+        width: parent.width
+        text: "Theme Sync"
+        font.pixelSize: Theme.fontSizeMedium
+        font.weight: Font.DemiBold
+        color: Theme.surfaceText
+    }
+
+    StyledText {
+        width: parent.width
+        text: "Synchronise your Hue lights with the DMS accent colour. The accent colour is read from the current theme and applied to all colour-capable lights."
+        font.pixelSize: Theme.fontSizeSmall
+        color: Theme.surfaceVariantText
+        wrapMode: Text.WordWrap
+    }
+
+    StyledRect {
+        width: parent.width
+        height: themeSyncColumn.implicitHeight + Theme.spacingL * 2
+        radius: Theme.cornerRadius
+        color: Theme.surfaceContainerHigh
+
+        Column {
+            id: themeSyncColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingL
+            spacing: Theme.spacingM
+
+            ToggleSetting {
+                settingKey: "autoSyncAccent"
+                label: "Auto-Sync Accent Colour"
+                description: "Automatically sync lights to the DMS accent colour whenever the theme changes."
+                defaultValue: false
+                onValueChanged: {
+                    if (value) {
+                        HueService.syncAllToAccent();
+                    }
+                }
+            }
+
+            StyledRect {
+                width: parent.width
+                height: 1
+                color: Theme.outline
+                opacity: 0.2
+            }
+
+            StyledText {
+                text: "Sync Rooms"
+                font.pixelSize: Theme.fontSizeSmall
+                font.weight: Font.Medium
+                color: Theme.surfaceText
+            }
+
+            StyledText {
+                width: parent.width
+                text: "Choose which rooms to sync. Empty selection = all rooms."
+                font.pixelSize: Theme.fontSizeSmall - 1
+                color: Theme.surfaceVariantText
+                wrapMode: Text.WordWrap
+            }
+
+            Repeater {
+                model: Array.from(HueService.rooms.values())
+
+                delegate: Row {
+                    spacing: Theme.spacingS
+                    anchors.left: parent.left
+
+                    CheckBox {
+                        id: roomCheck
+                        checked: {
+                            const sel = HueService._syncRoomIds;
+                            return sel.size === 0 || sel.has(modelData.entityId);
+                        }
+                        onCheckedChanged: {
+                            const sel = HueService._syncRoomIds;
+                            if (checked) {
+                                sel.add(modelData.entityId);
+                            } else {
+                                sel.delete(modelData.entityId);
+                            }
+                        }
+                    }
+
+                    StyledText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: modelData.name
+                        font.pixelSize: Theme.fontSizeSmall
+                        color: Theme.surfaceText
+                    }
+                }
+            }
+
+            StyledRect {
+                width: parent.width
+                height: 1
+                color: Theme.outline
+                opacity: 0.2
+            }
+
+            Column {
+                width: parent.width
+                spacing: Theme.spacingS
+
+                StyledText {
+                    text: "Accent Colour Preview"
+                    font.pixelSize: Theme.fontSizeSmall
+                    font.weight: Font.Medium
+                    color: Theme.surfaceText
+                }
+
+                Row {
+                    spacing: Theme.spacingM
+                    anchors.left: parent.left
+
+                    Rectangle {
+                        id: accentPreview
+                        width: 32
+                        height: 32
+                        radius: Theme.cornerRadiusSmall
+                        color: Theme.currentThemeData?.primary ?? "#42a5f5"
+                        border.width: 1
+                        border.color: Qt.rgba(Theme.surfaceText.r, Theme.surfaceText.g, Theme.surfaceText.b, 0.2)
+                    }
+
+                    Column {
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Theme.spacingXS
+
+                        StyledText {
+                            text: Theme.currentThemeData?.primary ?? "#42a5f5"
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            font.family: "monospace"
+                        }
+
+                        StyledText {
+                            text: "Current accent colour from theme"
+                            font.pixelSize: Theme.fontSizeSmall - 1
+                            color: Theme.surfaceVariantText
+                        }
+                    }
+                }
+            }
+
+            DankButton {
+                id: syncNowButton
+                width: parent.width
+                text: "Sync Now"
+                iconName: "sync"
+                enabled: HueService.isReady && HueService.lights.size > 0
+                onClicked: {
+                    HueService.syncAllToAccent();
+                }
+            }
+
+            StyledText {
+                width: parent.width
+                text: {
+                    if (!HueService.isReady)
+                        return "Hue service is not ready yet.";
+                    if (HueService.lights.size === 0)
+                        return "No lights found. Make sure your Hue bridge is configured.";
+                    return "This will apply the current accent colour to colour-capable lights that are turned on in the selected rooms.";
+                }
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.surfaceVariantText
+                wrapMode: Text.WordWrap
             }
         }
     }

--- a/src/Service/Commands.qml
+++ b/src/Service/Commands.qml
@@ -9,28 +9,68 @@ QtObject {
     required property string openHuePath
     required property var refresh
 
+    property var _queue: []
+    property bool _dispatching: false
+
+    function _dispatch() {
+        if (_dispatching || _queue.length === 0) {
+            return;
+        }
+
+        _dispatching = true;
+
+        const item = _queue.shift();
+
+        Proc.runCommand(item.key, item.args, (output, exitCode) => {
+            item.onComplete(output, exitCode);
+            _dispatching = false;
+            _dispatch();
+        }, 100);
+    }
+
+    function _enqueue(key, args, onComplete) {
+        const idx = _queue.findIndex(i => i.key === key);
+
+        const item = {
+            key,
+            args,
+            onComplete
+        };
+
+        if (idx >= 0) {
+            _queue[idx] = item;
+        } else {
+            _queue.push(item);
+        }
+
+        _dispatch();
+    }
+
     function executeEntityCommand(commandName, entity, args, errorMessage) {
         const fullArgs = [openHuePath, "set", entity.entityType, entity.entityId, ...args];
+        const key = `${pluginId}.${commandName}.${entity.entityId}`;
 
-        Proc.runCommand(`${pluginId}.${commandName}`, fullArgs, (output, exitCode) => {
+        _enqueue(key, fullArgs, (output, exitCode) => {
             if (output !== "" || exitCode !== 0) {
                 ToastService.showError("Hue Manager Error", errorMessage);
                 console.error(`${pluginId}: ${errorMessage}:`, output);
                 Qt.callLater(refresh);
             }
-        }, 100);
+        });
     }
 
     function executeSceneCommand(commandName, args, errorMessage) {
         const fullArgs = [openHuePath, "set", "scene", ...args];
+        const sceneId = args[0];
+        const key = `${pluginId}.${commandName}.${sceneId}`;
 
-        Proc.runCommand(`${pluginId}.${commandName}`, fullArgs, (output, exitCode) => {
+        _enqueue(key, fullArgs, (output, exitCode) => {
             if (!output.trim().includes("activated") || exitCode !== 0) {
                 ToastService.showError("Hue Manager Error", errorMessage);
                 console.error(`${pluginId}: ${errorMessage}:`, output.trim());
                 Qt.callLater(refresh);
             }
-        }, 100);
+        });
     }
 
     function applyEntityPower(entity, turnOn) {

--- a/src/Service/Commands.qml
+++ b/src/Service/Commands.qml
@@ -52,6 +52,10 @@ QtObject {
         executeEntityCommand("setEntityTemperature", entity, ["--temperature", tempValue.toString()], `Failed to set ${entity.entityType} temperature ${entity.entityId}`);
     }
 
+    function applyRoomAccent(room, color) {
+        executeEntityCommand("setRoomAccent", room, ["--on", "--rgb", color], `Failed to set room ${room.name} colour`);
+    }
+
     function applyActivateScene(scene) {
         executeSceneCommand("activateScene", [scene.id], `Failed to activate scene ${scene.id}`);
     }

--- a/src/Service/Room.qml
+++ b/src/Service/Room.qml
@@ -71,4 +71,8 @@ Entity {
         room.scenes.forEach(s => s.active = false);
         room.activeScene = null;
     }
+
+    function setAccent(color) {
+        _service.commands.applyRoomAccent(room, color);
+    }
 }

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -368,12 +368,18 @@ Item {
                 return;
             }
             console.log(`${pluginId}: Syncing room "${room.name}" to accent colour ${accentColor}`);
+            let roomLightCount = 0;
             service.lights.forEach(light => {
-                if (light.room && light.room.id === roomId && light.isColorCapable && light.on) {
+                const matched = light.room && light.room.id === roomId;
+                console.log(`${pluginId}:   light="${light.name}" room_id=${light.room?.id} matched=${matched} colorCapable=${light.isColorCapable} on=${light.on}`);
+                if (matched && light.isColorCapable && light.on) {
+                    roomLightCount++;
+                    console.log(`${pluginId}:   -> would sync ${light.name}`);
                     service.commands.applyEntityColor(light, accentColor);
                     syncedCount++;
                 }
             });
+            console.log(`${pluginId}:   total lights in room: ${roomLightCount}`);
         } else {
             // Sync filtered rooms or all rooms
             console.log(`${pluginId}: Syncing colour-capable lights to accent colour ${accentColor}`);
@@ -390,7 +396,9 @@ Item {
                 });
             } else {
                 service.lights.forEach(light => {
+                    console.log(`${pluginId}:   checking light="${light.name}" colorCapable=${light.isColorCapable} on=${light.on}`);
                     if (light.isColorCapable && light.on) {
+                        console.log(`${pluginId}:   -> syncing ${light.name}`);
                         service.commands.applyEntityColor(light, accentColor);
                         syncedCount++;
                     }

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -45,6 +45,16 @@ Item {
         refresh: service.refresh
     }
 
+    Connections {
+        target: Theme
+
+        function onCurrentThemeDataChanged() {
+            if (service.autoSyncAccent && service.isReady && Theme.currentThemeData?.primary) {
+                service.syncAllToAccent();
+            }
+        }
+    }
+
     EventHandler {
         id: eventHandler
         service: service

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -344,6 +344,63 @@ Item {
         }
     }
 
+    property var _syncRoomIds: new Set()  // set of room IDs to sync; empty = all rooms
+
+    function syncAllToAccent(roomId) {
+        if (!service.isReady) {
+            console.warn(`${pluginId}: Cannot sync accent - service is not ready`);
+            return;
+        }
+
+        const accentColor = Theme.currentThemeData?.primary;
+        if (!accentColor) {
+            console.warn(`${pluginId}: Cannot sync accent - no accent colour available`);
+            return;
+        }
+
+        let syncedCount = 0;
+
+        if (roomId) {
+            // Sync a single room — match lights by room ID
+            const room = service.rooms.get(roomId);
+            if (!room) {
+                console.warn(`${pluginId}: Room ${roomId} not found`);
+                return;
+            }
+            console.log(`${pluginId}: Syncing room "${room.name}" to accent colour ${accentColor}`);
+            service.lights.forEach(light => {
+                if (light.room && light.room.id === roomId && light.isColorCapable && light.on) {
+                    service.commands.applyEntityColor(light, accentColor);
+                    syncedCount++;
+                }
+            });
+        } else {
+            // Sync filtered rooms or all rooms
+            console.log(`${pluginId}: Syncing colour-capable lights to accent colour ${accentColor}`);
+            const filterRoomIds = service._syncRoomIds.size > 0 ? service._syncRoomIds : null;
+
+            if (filterRoomIds) {
+                filterRoomIds.forEach(rid => {
+                    service.lights.forEach(light => {
+                        if (light.room && light.room.id === rid && light.isColorCapable && light.on) {
+                            service.commands.applyEntityColor(light, accentColor);
+                            syncedCount++;
+                        }
+                    });
+                });
+            } else {
+                service.lights.forEach(light => {
+                    if (light.isColorCapable && light.on) {
+                        service.commands.applyEntityColor(light, accentColor);
+                        syncedCount++;
+                    }
+                });
+            }
+        }
+
+        console.log(`${pluginId}: Synced ${syncedCount} colour-capable lights to accent colour ${accentColor}`);
+    }
+
     function setError(message) {
         console.error(`${pluginId}: ${message}`);
         service.isError = true;

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -48,7 +48,7 @@ Item {
         refresh: service.refresh
     }
 
-Connections {
+    Connections {
         target: Theme
 
         function onCurrentThemeDataChanged() {
@@ -61,6 +61,11 @@ Connections {
         function onCurrentThemeChanged() {
             if (service.autoSyncAccent && service.isReady) {
                 console.log(`${pluginId}: Auto-sync triggered by theme change to "${Theme.currentTheme}"`);
+                // Defer sync until the next event loop tick so that
+                // Theme.currentThemeData has finished updating.
+                // onCurrentThemeDataChanged fires separately, but when
+                // the theme name changes we need to wait for the new
+                // theme's colour data to be resolved before syncing.
                 Qt.callLater(() => {
                     if (Theme.currentThemeData?.primary) {
                         service.syncAllToAccent();
@@ -222,6 +227,20 @@ Connections {
         openHuePath = load("openHuePath");
         jqPath = load("jqPath");
         useDeviceIcons = load("useDeviceIcons");
+        loadSyncRoomIds();
+    }
+
+    function loadSyncRoomIds() {
+        const saved = PluginService.loadPluginData(pluginId, "syncRoomIds");
+        if (saved && Array.isArray(saved)) {
+            service._syncRoomIds = new Set(saved);
+        } else {
+            service._syncRoomIds = new Set();
+        }
+    }
+
+    function saveSyncRoomIds() {
+        PluginService.savePluginData(pluginId, "syncRoomIds", Array.from(service._syncRoomIds));
     }
 
     function checkDependencies(onComplete) {

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -440,35 +440,28 @@ Item {
             return;
         }
 
-        let syncedCount = 0;
-
         if (roomId) {
-            // Sync a single room by name using openhue set room
             const room = service.rooms.get(roomId);
+
             if (!room) {
                 console.warn(`${pluginId}: Room ${roomId} not found`);
                 return;
             }
-            console.log(`${pluginId}: Syncing room "${room.name}" to accent colour ${accentColor}`);
-            service.commands.executeEntityCommand("setRoomAccent", room, ["--on", "--rgb", accentColor],
-                `Failed to set room ${room.name} colour`);
-            syncedCount = 1;
+
+            room.setAccent(accentColor);
+            console.log(`${pluginId}: Synced room "${room.name}" to accent colour ${accentColor}`);
         } else {
-            console.log(`${pluginId}: Syncing rooms to accent colour ${accentColor}`);
-            const filterRoomIds = service._syncRoomIds.size > 0 ? service._syncRoomIds : null;
-            const roomsToSync = filterRoomIds
-                ? Array.from(filterRoomIds).map(rid => service.rooms.get(rid)).filter(r => r)
-                : Array.from(service.rooms.values());
+            const allRooms = Array.from(service.rooms.values());
+            const selectedRooms = Array.from(service._syncRoomIds).map(rId => service.rooms.get(rId)).filter(r => r);
+            const roomsToSync = service._syncRoomIds.size > 0 ? selectedRooms : allRooms;
 
             roomsToSync.forEach(room => {
                 console.log(`${pluginId}:   syncing room "${room.name}"`);
-                service.commands.executeEntityCommand("setRoomAccent", room, ["--on", "--rgb", accentColor],
-                    `Failed to set room ${room.name} colour`);
-                syncedCount++;
+                room.setAccent(accentColor);
             });
-        }
 
-        console.log(`${pluginId}: Synced ${syncedCount} room(s) to accent colour ${accentColor}`);
+            console.log(`${pluginId}: Synced ${roomsToSync.length} room(s) to accent colour ${accentColor}`);
+        }
     }
 
     function setError(message) {

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -20,6 +20,9 @@ Item {
     property string jqPath: defaults.jqPath
     property bool useDeviceIcons: defaults.useDeviceIcons
 
+    // Read from PluginService settings, not a local property
+    readonly property bool autoSyncAccent: PluginService.loadPluginData(pluginId, "autoSyncAccent") ?? false
+
     property bool isReady: false
     property bool isError: false
     property string errorMessage: ""
@@ -45,7 +48,7 @@ Item {
         refresh: service.refresh
     }
 
-    Connections {
+Connections {
         target: Theme
 
         function onCurrentThemeDataChanged() {
@@ -182,6 +185,10 @@ Item {
         function onPluginDataChanged(pluginId) {
             if (pluginId === service.pluginId) {
                 service.loadSettings();
+                // autoSyncAccent is a readonly binding, so re-check it when data changes
+                if (PluginService.loadPluginData(service.pluginId, "autoSyncAccent") && service.isReady && Theme.currentThemeData?.primary) {
+                    service.syncAllToAccent();
+                }
             }
         }
     }

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -361,52 +361,32 @@ Item {
         let syncedCount = 0;
 
         if (roomId) {
-            // Sync a single room — match lights by room ID
+            // Sync a single room by name using openhue set room
             const room = service.rooms.get(roomId);
             if (!room) {
                 console.warn(`${pluginId}: Room ${roomId} not found`);
                 return;
             }
             console.log(`${pluginId}: Syncing room "${room.name}" to accent colour ${accentColor}`);
-            let roomLightCount = 0;
-            service.lights.forEach(light => {
-                const matched = light.room && light.room.id === roomId;
-                console.log(`${pluginId}:   light="${light.name}" room_id=${light.room?.id} matched=${matched} colorCapable=${light.isColorCapable} on=${light.on}`);
-                if (matched && light.isColorCapable && light.on) {
-                    roomLightCount++;
-                    console.log(`${pluginId}:   -> would sync ${light.name}`);
-                    service.commands.applyEntityColor(light, accentColor);
-                    syncedCount++;
-                }
-            });
-            console.log(`${pluginId}:   total lights in room: ${roomLightCount}`);
+            service.commands.executeEntityCommand("setRoomAccent", room, ["--on", "--rgb", accentColor],
+                `Failed to set room ${room.name} colour`);
+            syncedCount = 1;
         } else {
-            // Sync filtered rooms or all rooms
-            console.log(`${pluginId}: Syncing colour-capable lights to accent colour ${accentColor}`);
+            console.log(`${pluginId}: Syncing rooms to accent colour ${accentColor}`);
             const filterRoomIds = service._syncRoomIds.size > 0 ? service._syncRoomIds : null;
+            const roomsToSync = filterRoomIds
+                ? Array.from(filterRoomIds).map(rid => service.rooms.get(rid)).filter(r => r)
+                : Array.from(service.rooms.values());
 
-            if (filterRoomIds) {
-                filterRoomIds.forEach(rid => {
-                    service.lights.forEach(light => {
-                        if (light.room && light.room.id === rid && light.isColorCapable && light.on) {
-                            service.commands.applyEntityColor(light, accentColor);
-                            syncedCount++;
-                        }
-                    });
-                });
-            } else {
-                service.lights.forEach(light => {
-                    console.log(`${pluginId}:   checking light="${light.name}" colorCapable=${light.isColorCapable} on=${light.on}`);
-                    if (light.isColorCapable && light.on) {
-                        console.log(`${pluginId}:   -> syncing ${light.name}`);
-                        service.commands.applyEntityColor(light, accentColor);
-                        syncedCount++;
-                    }
-                });
-            }
+            roomsToSync.forEach(room => {
+                console.log(`${pluginId}:   syncing room "${room.name}"`);
+                service.commands.executeEntityCommand("setRoomAccent", room, ["--on", "--rgb", accentColor],
+                    `Failed to set room ${room.name} colour`);
+                syncedCount++;
+            });
         }
 
-        console.log(`${pluginId}: Synced ${syncedCount} colour-capable lights to accent colour ${accentColor}`);
+        console.log(`${pluginId}: Synced ${syncedCount} room(s) to accent colour ${accentColor}`);
     }
 
     function setError(message) {

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -50,6 +50,37 @@ Item {
 
         function onCurrentThemeDataChanged() {
             if (service.autoSyncAccent && service.isReady && Theme.currentThemeData?.primary) {
+                console.log(`${pluginId}: Auto-sync triggered by theme data change`);
+                service.syncAllToAccent();
+            }
+        }
+
+        function onCurrentThemeChanged() {
+            if (service.autoSyncAccent && service.isReady) {
+                console.log(`${pluginId}: Auto-sync triggered by theme change to "${Theme.currentTheme}"`);
+                Qt.callLater(() => {
+                    if (Theme.currentThemeData?.primary) {
+                        service.syncAllToAccent();
+                    }
+                });
+            }
+        }
+
+        function onIsLightModeChanged() {
+            if (service.autoSyncAccent && service.isReady && Theme.currentThemeData?.primary) {
+                console.log(`${pluginId}: Auto-sync triggered by light mode change`);
+                service.syncAllToAccent();
+            }
+        }
+    }
+
+    // Also listen for matugen color generation completion
+    Connections {
+        target: Theme
+
+        function onMatugenCompleted(mode, result) {
+            if (service.autoSyncAccent && service.isReady && Theme.currentThemeData?.primary) {
+                console.log(`${pluginId}: Auto-sync triggered by matugen completion`);
                 service.syncAllToAccent();
             }
         }

--- a/src/Service/Service.qml
+++ b/src/Service/Service.qml
@@ -236,6 +236,13 @@ Item {
             service._syncRoomIds = new Set(saved);
         } else {
             service._syncRoomIds = new Set();
+            // Fill with all current room IDs so checkboxes have explicit state
+            if (service.rooms.size > 0) {
+                for (const room of service.rooms.values()) {
+                    service._syncRoomIds.add(room.entityId);
+                }
+                service.saveSyncRoomIds();
+            }
         }
     }
 
@@ -348,6 +355,14 @@ Item {
             });
 
             service[property] = updatedEntities;
+
+            // After rooms are loaded, ensure _syncRoomIds is initialized
+            if (entityType === "room" && service._syncRoomIds.size === 0 && service.rooms.size > 0) {
+                for (const room of service.rooms.values()) {
+                    service._syncRoomIds.add(room.entityId);
+                }
+                service.saveSyncRoomIds();
+            }
         }, 100);
     }
 


### PR DESCRIPTION
Adds automatic accent colour syncing from DMS themes to Philips Hue lights.

    Features:
    - Auto-sync lights to DMS accent colour on theme change, light/dark mode toggle,
      and Matugen wallpaper colour generation
    - Per-room selection for which rooms to sync
    - Manual 'Sync Now' button in settings
    - Reads autoSyncAccent setting from PluginService